### PR TITLE
sklearn.externals is deprecated

### DIFF
--- a/PrimalCore/python/PrimalCore/models/base.py
+++ b/PrimalCore/python/PrimalCore/models/base.py
@@ -41,7 +41,7 @@ from sklearn.ensemble import GradientBoostingRegressor
 # relative import eg: from .mod import f
 from ..homogeneous_table.dataset_handler import check_dataset_decorate
 from ..io.fits import write_data
-from sklearn.externals import joblib
+import joblib
 import pickle
 class WrappedModel(object):
 

--- a/PrimalCore/python/PrimalCore/pdf/tools.py
+++ b/PrimalCore/python/PrimalCore/pdf/tools.py
@@ -113,9 +113,10 @@ def extract_pdf(model,
 
     c1 = pf.Column(name='original_row_ID', format='J', array=ml_dataset.features_original_entry_ID)
 
-    if  ml_dataset._target_array is not None:
+
+    try:
         z_spec=ml_dataset.target_array
-    else:
+    except TypeError:
         z_spec=np.ones(ml_dataset.features_N_rows)*-1
 
     c2 = pf.Column(name='z_spec', format='D', array=z_spec)

--- a/PrimalCore/python/PrimalCore/pdf/tools.py
+++ b/PrimalCore/python/PrimalCore/pdf/tools.py
@@ -112,7 +112,13 @@ def extract_pdf(model,
         print('prediction on random done')
 
     c1 = pf.Column(name='original_row_ID', format='J', array=ml_dataset.features_original_entry_ID)
-    c2 = pf.Column(name='z_spec', format='D', array=ml_dataset.target_array)
+
+    try:
+        z_spec=ml_dataset.target_array
+    except TypeError:
+        z_spec=np.ones(ml_dataset.features_N_rows)*-1
+
+    c2 = pf.Column(name='z_spec', format='D', array=z_spec)
     c3 = pf.Column(name='z_phot', format='D', array=z_phot)
     c4 = pf.Column(name='z_phot_values', format='%dD'%(trials), )
     c5 = pf.Column(name='z_phot_pdf_grid', format='%dD' % (pdf_grid_size), )

--- a/PrimalCore/python/PrimalCore/pdf/tools.py
+++ b/PrimalCore/python/PrimalCore/pdf/tools.py
@@ -113,9 +113,9 @@ def extract_pdf(model,
 
     c1 = pf.Column(name='original_row_ID', format='J', array=ml_dataset.features_original_entry_ID)
 
-    try:
+    if  ml_dataset._target_array is not None:
         z_spec=ml_dataset.target_array
-    except TypeError:
+    else:
         z_spec=np.ones(ml_dataset.features_N_rows)*-1
 
     c2 = pf.Column(name='z_spec', format='D', array=z_spec)


### PR DESCRIPTION
> sklearn.externals.joblib is deprecated in 0.21 and will be removed in 0.23

Import top-level `joblib` library instead.